### PR TITLE
Fix typos and update links 

### DIFF
--- a/CPU.md
+++ b/CPU.md
@@ -26,8 +26,8 @@ Common issues with AMD:
 * Not all USB ports work on some boards
    * This is due to not being assigned in ACPI, you need to manually add them in your DSDT
 * Delayed updates
-* **3rd Gen Threadripper is not supported on bare-metal**
-  * KVM solution is the only work-around at this moment 
+* ~~3rd Gen Threadripper is not supported on bare-metal~~
+  * Latest BIOS and OpenCore now boot with TRx40 CPUs
 
 AMD CPUs:
 * AMD Ryzen 1000 Series
@@ -72,13 +72,3 @@ This mainly consists of CPUs that are missing the SSE4.2 instruction set require
    * E9xxx
 
 Then there's the CPUs that are missing the SSE4.1 and older instruction sets, with these support is stuck an OS X 10.11 El Capitan
-
-
-**Too new to run**
-
-Well with this, the only current solution is to run it in a KVM, this is due to the current kernel patches not supporting 19h
-
-* 3rd Gen Threadripper
-   * 3960X
-   * 3970X
-   * 3990X(the macOS kernel doesn't even support more than 64 threads)

--- a/Motherboard.md
+++ b/Motherboard.md
@@ -85,7 +85,7 @@ Note (*): Only get these in case you need features from these that aren't found 
 
 With audio, most boards are supported and you can find a more extensive list from [AppleALC](https://github.com/acidanthera/AppleALC/wiki/Supported-codecs) for audio. VoodooHDA is another option for legacy users
 
-**note**: AMD motherboard users will require VoodooHDA if you plan to use the onboard microphone header. Regulkar audio putput works however with AppleALC
+**Note**: AMD motherboard users will require VoodooHDA if you plan to use the onboard microphone header. However, regular audio output works with AppleALC
 
 ---
 
@@ -111,7 +111,7 @@ For legacy ethernet controllers, you have a couple to choose from(systems with t
 
 **Note**: Realtek L8200A is outright unsupported, for a full list see [Networking section](/Networking.md)
 
-**Note 2**: For those planning on buying Intel's Z490 boards, please note that the i225-V NIC is not supported officially without a device-id spoof. Example of this can be found here: [Comet Lake i225-V spoof](https://dortania.github.io/OpenCore-Install-Guide/config.plist/comet-lake.html#starting-point)
+**Note 2**: For those planning on buying Intel's Z490 boards, please note that the i225-V NIC is not supported officially without a device-id spoof. Example of this can be found here: [Comet Lake i225-V spoof](https://dortania.github.io/OpenCore-Install-Guide/config.plist/comet-lake.html#deviceproperties)
 
 ---
 
@@ -182,7 +182,7 @@ So we need to either:
 * [create a fake systems clock](https://github.com/acidanthera/OpenCorePkg/blob/master/Docs/AcpiSamples/SSDT-RTC0.dsl) 
 * [patch it out](https://www.hackintosh-forum.de/forum/thread/39846-asrock-z390-taichi-ultimate/?pageNo=2)
 
-You can find more info here on **how** to fix it: [Getting started with ACPI](https://khronokernel.github.io/Getting-Started-With-ACPI/)
+You can find more info here on **how** to fix it: [Getting started with ACPI](https://dortania.github.io/Getting-Started-With-ACPI/)
 
 ---
 


### PR DESCRIPTION
I've fixed some minor typos on the Audio section and updated the starting with ACPI link to the new site as well as the link to the Comet Lake i225-V spoof so that it's easier to find. 