### PR TITLE
SK Hynix PC711 SSD Unsupported

### DIFF
--- a/Storage.md
+++ b/Storage.md
@@ -15,6 +15,8 @@ And while not an issue anymore, do note that all of Apple's PCIe drives are 4K s
   * Even if PM981 has been fixed with [NVMeFix](https://github.com/acidanthera/NVMeFix/releases) version 1.0.2 there is still plenty of kernel panics issues
 * Micron 2200S
   * Many users have report boot issues with this drive
+* SK Hynix PC711
+  * The proprietary Hynix NVMe controller on this drive is not supported at all, and it will not boot with macOS
 
 **SSDs to avoid**
 


### PR DESCRIPTION
Add SSD to unsupported list based on personal testing in macOS with this SSD. This SSD is mainly used by OEMs (especially Dell) and no firmware revision I tried was compatible with macOS.